### PR TITLE
Add 'set_reload_mode' to timer API

### DIFF
--- a/src/c_api.rs
+++ b/src/c_api.rs
@@ -19,6 +19,11 @@ pub extern "C" fn start_timer() {
 }
 
 #[no_mangle]
+pub extern "C" fn set_reload_mode(auto_reload: bool) {
+    Timer::set_reload_mode(auto_reload)
+}
+
+#[no_mangle]
 pub extern "C" fn change_period_timer(period: Duration) {
     Timer::change_period_timer(period)
 }

--- a/src/ports/mips64/mod.rs
+++ b/src/ports/mips64/mod.rs
@@ -19,10 +19,14 @@ impl PortTrait for Mips64 {
         hardware_timer::start_hardware_timer();
     }
 
+    fn set_reload_mode(auto_reload: bool) {
+        hardware_timer::set_reload_mode(auto_reload);
+    }
+
     fn change_period_timer(period: core::time::Duration) {
         hardware_timer::change_period_timer(period);
     }
-  
+
     fn get_time() -> core::time::Duration {
         hardware_timer::get_time()
     }

--- a/src/ports/mod.rs
+++ b/src/ports/mod.rs
@@ -3,20 +3,21 @@ use core::time::Duration;
 #[cfg(feature = "network")]
 use esp_wifi::esp_now::EspNow;
 
-
 /// PortTrait contains all the platform specific functions.
 pub trait PortTrait {
     /// Function is called when timer is created. Can be used to set configuration.
     fn setup_hardware_timer();
     /// Function is called to start timer.
     fn start_hardware_timer();
+    /// Function is used to change timer operating mode.
+    fn set_reload_mode(auto_reload: bool);
     /// Function is used to change the period of a timer.
     fn change_period_timer(period: Duration);
-    /// Function used to get amount of time from the start of a timer.
+    /// Function is used to get amount of time from the start of a timer.
     fn get_time() -> Duration;
     /// Function is called to stop timer.
     fn stop_hardware_timer() -> bool;
-  
+
     /// Function is called when heap is created. Can be used to set configuration.
     fn init_heap();
     #[cfg(feature = "network")]

--- a/src/ports/mok/hardware_timer.rs
+++ b/src/ports/mok/hardware_timer.rs
@@ -6,10 +6,13 @@ pub fn setup_hardware_timer() {}
 /// Mok start harware timer.
 pub fn start_hardware_timer() {}
 
-/// Mok change the period of a timer.
+/// Mok change operating mode of hardware timer.
+pub fn set_reload_mode(_auto_reload: bool) {}
+
+/// Mok change the period of hardware timer.
 pub fn change_period_timer(_period: Duration) {}
 
-/// Mok getting counter value.
+/// Mok getting counter value of hardware timer.
 pub fn get_time() -> Duration {
     Duration::new(0, 0)
 }

--- a/src/ports/mok/mod.rs
+++ b/src/ports/mok/mod.rs
@@ -19,6 +19,10 @@ impl PortTrait for Mok {
         hardware_timer::start_hardware_timer();
     }
 
+    fn set_reload_mode(auto_reload: bool) {
+        hardware_timer::set_reload_mode(auto_reload);
+    }
+
     fn change_period_timer(period: core::time::Duration) {
         hardware_timer::change_period_timer(period);
     }

--- a/src/ports/xtensa_esp32/hardware_timer.rs
+++ b/src/ports/xtensa_esp32/hardware_timer.rs
@@ -35,10 +35,13 @@ pub fn setup_hardware_timer() {
 /// Esp32 start harware timer.
 pub fn start_hardware_timer() {}
 
-/// Esp32 change the period of a timer.
+/// Esp32 change operating mode of hardware timer.
+pub fn set_reload_mode(auto_reload: bool) {}
+
+/// Esp32 change the period of hardware timer.
 pub fn change_period_timer(period: Duration) {}
 
-/// Esp32 getting counter value.
+/// Esp32 getting counter value of hardware timer.
 pub fn get_time() -> Duration {
     unsafe {
         let timer00 = TIMER00.take().expect("Timer error");

--- a/src/ports/xtensa_esp32/mod.rs
+++ b/src/ports/xtensa_esp32/mod.rs
@@ -22,6 +22,10 @@ impl PortTrait for XtensaEsp32 {
         hardware_timer::start_hardware_timer();
     }
 
+    fn set_reload_mode(auto_reload: bool) {
+        hardware_timer::set_reload_mode(auto_reload);
+    }
+
     fn change_period_timer(period: core::time::Duration) {
         hardware_timer::change_period_timer(period);
     }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -28,7 +28,7 @@ impl Timer {
         Port::start_hardware_timer()
     }
 
-    /// Updates the opearting mode of the timer to be either an auto reload timer or a one-shot timer.
+    /// Updates the operating mode of the timer to be either an auto reload timer or a one-shot timer.
     pub fn set_reload_mode(auto_reload: bool) {
         Port::set_reload_mode(auto_reload)
     }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -28,6 +28,11 @@ impl Timer {
         Port::start_hardware_timer()
     }
 
+    /// Updates the opearting mode of the timer to be either an auto reload timer or a one-shot timer.
+    pub fn set_reload_mode(auto_reload: bool) {
+        Port::set_reload_mode(auto_reload)
+    }
+
     /// Changes the timer period.
     pub fn change_period_timer(period: Duration) {
         Port::change_period_timer(period);


### PR DESCRIPTION
Added to the API and implemented the function "set_reload_mode", which updates the timer operating mode, setting it either to automatic reboot mode or to one-time timer mode.